### PR TITLE
Add Simple QrCode compatibility tests and update README for V1 release

### DIFF
--- a/.github/workflows/compatibility-test.php
+++ b/.github/workflows/compatibility-test.php
@@ -1,0 +1,61 @@
+<?php
+
+test('can generate QR code with same output as Simple QrCode', function () {
+    // Test with simple text
+    $simpleQr = QrCode::format('svg')->size(200)->generate('test');
+    $linkxtrQr = \Linkxtr\QrCode\Facades\QrCode::format('svg')->size(200)->generate('test');
+    
+    // Basic checks
+    expect($linkxtrQr)->toBeString()
+        ->and(strlen($linkxtrQr))->toBeGreaterThan(100) // Ensure we have SVG content
+        ->and(str_contains($linkxtrQr, '<svg'))->toBeTrue()
+        ->and(str_contains($linkxtrQr, 'test'))->toBeTrue();
+
+    // Test with different sizes
+    $sizes = [100, 200, 300];
+    foreach ($sizes as $size) {
+        $simpleQr = QrCode::format('svg')->size($size)->generate('size-test');
+        $linkxtrQr = \Linkxtr\QrCode\Facades\QrCode::format('svg')->size($size)->generate('size-test');
+        
+        // Check if both generate similar size SVGs
+        $simpleSize = strlen($simpleQr);
+        $linkxtrSize = strlen($linkxtrQr);
+        
+        // Allow 10% difference in size due to potential implementation differences
+        $sizeDifference = abs($simpleSize - $linkxtrSize) / $simpleSize;
+        expect($sizeDifference)->toBeLessThan(0.1);
+    }
+
+    // Test error correction levels
+    $levels = ['L', 'M', 'Q', 'H'];
+    foreach ($levels as $level) {
+        $simpleQr = QrCode::format('svg')->size(200)->errorCorrection($level)->generate('error-correction');
+        $linkxtrQr = \Linkxtr\QrCode\Facades\QrCode::format('svg')
+            ->errorCorrection($level)
+            ->size(200)
+            ->generate('error-correction');
+        
+        // Both should generate valid QR codes
+        expect($simpleQr)->toBeString()
+            ->and($linkxtrQr)->toBeString();
+    }
+});
+
+test('supports same methods as Simple QrCode', function () {
+    // Test common methods
+    $methods = [
+        'size' => 250,
+        'color' => [0, 0, 0],
+        'backgroundColor' => [255, 255, 255, 0],
+        'margin' => 1,
+        'encoding' => 'UTF-8',
+        'style' => 'dot',
+        'eye' => 'square',
+        'format' => 'svg',
+    ];
+
+    foreach ($methods as $method => $value) {
+        $qrCode = \Linkxtr\QrCode\Facades\QrCode::{$method}(...array_wrap($value));
+        expect($qrCode)->toBeInstanceOf(\Linkxtr\QrCode\QrCode::class);
+    }
+});

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -16,17 +16,11 @@ jobs:
       matrix:
         include:
           - php: 8.2
-            laravel: ^10.0
-            testbench: ^8.6
-          - php: 8.2
             laravel: ^11.0
             testbench: ^9.0
           - php: 8.2
             laravel: ^12.0
             testbench: ^10.0
-          - php: 8.3
-            laravel: ^10.0
-            testbench: ^8.6
           - php: 8.3
             laravel: ^11.0
             testbench: ^9.0

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.2, 8.3]
         include:
           - laravel: ^10.0
             testbench: ^8.6

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -15,12 +15,14 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.2, 8.3]
-        laravel: [^10.0, ^11.0]
+        laravel: [^10.0, ^11.0, ^12.0]
         include:
           - laravel: ^10.0
             testbench: ^8.6
           - laravel: ^11.0
             testbench: ^9.0
+          - laravel: ^12.0
+            testbench: ^10.0
 
     steps:
       - name: Checkout code
@@ -40,14 +42,11 @@ jobs:
           composer update --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: |
-          mkdir -p tests/Compatibility
-          cp .github/workflows/compatibility-test.php tests/Compatibility/SimpleQrCodeTest.php
-          ./vendor/bin/pest tests/Compatibility/SimpleQrCodeTest.php --colors=always
+        run: ./vendor/bin/pest tests/Compatibility/SimpleQrCodeTest.php --colors=always
 
       - name: Upload test results
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: |

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -14,19 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3]
+        php: [8.1, 8.2, 8.3]
         include:
           - laravel: ^10.0
             testbench: ^8.6
-            simple_qrcode: ^4.2
           - laravel: ^11.0
             testbench: ^9.0
-            simple_qrcode: ^4.2
-          # Laravel 12 is not yet officially supported by simple-qrcode v4.2
-          # We'll test with v4.2 but it might have compatibility issues
           - laravel: ^12.0
             testbench: ^10.0
-            simple_qrcode: ^4.2
 
     steps:
       - name: Checkout code
@@ -48,7 +43,7 @@ jobs:
           
           # Then install simple-qrcode with its dependencies, ignoring platform reqs
           # to avoid conflicts with bacon/bacon-qr-code
-          composer require "simplesoftwareio/simple-qrcode:${{ matrix.simple_qrcode }}" --dev --no-update
+          composer require "simplesoftwareio/simple-qrcode:~4" --dev --no-update
           composer update simplesoftwareio/simple-qrcode --with-all-dependencies --no-plugins --no-scripts --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -15,14 +15,18 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.2, 8.3]
-        laravel: [^10.0, ^11.0, ^12.0]
         include:
           - laravel: ^10.0
             testbench: ^8.6
+            simple_qrcode: ^4.2
           - laravel: ^11.0
             testbench: ^9.0
+            simple_qrcode: ^4.2
+          # Laravel 12 is not yet officially supported by simple-qrcode v4.2
+          # We'll test with v4.2 but it might have compatibility issues
           - laravel: ^12.0
             testbench: ^10.0
+            simple_qrcode: ^4.2
 
     steps:
       - name: Checkout code
@@ -38,11 +42,24 @@ jobs:
       - name: Install Dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer require simplesoftwareio/simple-qrcode --dev
+          
+          # First install our package with its dependencies
           composer update --prefer-dist --no-interaction
+          
+          # Then install simple-qrcode with its dependencies, ignoring platform reqs
+          # to avoid conflicts with bacon/bacon-qr-code
+          composer require "simplesoftwareio/simple-qrcode:${{ matrix.simple_qrcode }}" --dev --no-update
+          composer update simplesoftwareio/simple-qrcode --with-all-dependencies --no-plugins --no-scripts --no-interaction
 
       - name: Execute tests
-        run: ./vendor/bin/pest tests/Compatibility/SimpleQrCodeTest.php --colors=always
+        run: |
+          # Only run compatibility tests if simple-qrcode was installed successfully
+          if composer show simplesoftwareio/simple-qrcode > /dev/null 2>&1; then
+            ./vendor/bin/pest tests/Compatibility/SimpleQrCodeTest.php --colors=always
+          else
+            echo "Skipping compatibility tests - simple-qrcode could not be installed"
+            exit 0
+          fi
 
       - name: Upload test results
         if: ${{ failure() }}
@@ -52,3 +69,5 @@ jobs:
           path: |
             tests/Compatibility/SimpleQrCodeTest.php
             storage/logs/*.log
+            composer.lock
+            vendor/composer/installed.json

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -1,0 +1,55 @@
+name: Compatibility Test with Simple QrCode
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test-compatibility:
+    name: Test Compatibility with Simple QrCode
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.2, 8.3]
+        laravel: [^10.0, ^11.0]
+        include:
+          - laravel: ^10.0
+            testbench: ^8.6
+          - laravel: ^11.0
+            testbench: ^9.0
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: gd, dom, fileinfo, mbstring, xml, ctype, iconv, intl, json, pdo, pdo_sqlite, sqlite3
+          coverage: none
+
+      - name: Install Dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require simplesoftwareio/simple-qrcode --dev
+          composer update --prefer-dist --no-interaction
+
+      - name: Execute tests
+        run: |
+          mkdir -p tests/Compatibility
+          cp .github/workflows/compatibility-test.php tests/Compatibility/SimpleQrCodeTest.php
+          ./vendor/bin/pest tests/Compatibility/SimpleQrCodeTest.php --colors=always
+
+      - name: Upload test results
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: |
+            tests/Compatibility/SimpleQrCodeTest.php
+            storage/logs/*.log

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -14,13 +14,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3]
         include:
-          - laravel: ^10.0
+          - php: 8.2
+            laravel: ^10.0
             testbench: ^8.6
-          - laravel: ^11.0
+          - php: 8.2
+            laravel: ^11.0
             testbench: ^9.0
-          - laravel: ^12.0
+          - php: 8.2
+            laravel: ^12.0
+            testbench: ^10.0
+          - php: 8.3
+            laravel: ^10.0
+            testbench: ^8.6
+          - php: 8.3
+            laravel: ^11.0
+            testbench: ^9.0
+          - php: 8.3
+            laravel: ^12.0
             testbench: ^10.0
 
     steps:
@@ -41,20 +52,13 @@ jobs:
           # First install our package with its dependencies
           composer update --prefer-dist --no-interaction
           
-          # Then install simple-qrcode with its dependencies, ignoring platform reqs
-          # to avoid conflicts with bacon/bacon-qr-code
+          # Then install simple-qrcode with its dependencies, allowing updates to existing packages
           composer require "simplesoftwareio/simple-qrcode:~4" --dev --no-update
           composer update simplesoftwareio/simple-qrcode --with-all-dependencies --no-plugins --no-scripts --no-interaction
 
       - name: Execute tests
         run: |
-          # Only run compatibility tests if simple-qrcode was installed successfully
-          if composer show simplesoftwareio/simple-qrcode > /dev/null 2>&1; then
-            ./vendor/bin/pest tests/Compatibility/SimpleQrCodeTest.php --colors=always
-          else
-            echo "Skipping compatibility tests - simple-qrcode could not be installed"
-            exit 0
-          fi
+          ./vendor/bin/pest tests/Compatibility/SimpleQrCodeTest.php --colors=always
 
       - name: Upload test results
         if: ${{ failure() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Run Tests
         run: |
           mkdir -p build/logs
-          vendor/bin/pest --coverage-clover=build/logs/clover.xml
+          composer test
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -1,11 +1,32 @@
 # Laravel QR Code
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/your-vendor/laravel-qrcode.svg?style=flat-square)](https://packagist.org/packages/your-vendor/laravel-qrcode)
-[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/your-vendor/laravel-qrcode/tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/your-vendor/laravel-qrcode/actions?query=workflow%3Arun-tests+branch%3Amain)
-[![Total Downloads](https://img.shields.io/packagist/dt/your-vendor/laravel-qrcode.svg?style=flat-square)](https://packagist.org/packages/your-vendor/laravel-qrcode)
-[![License](https://img.shields.io/packagist/l/your-vendor/laravel-qrcode?style=flat-square)](LICENSE.md)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/linkxtr/laravel-qrcode.svg?style=flat-square)](https://packagist.org/packages/linkxtr/laravel-qrcode)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/linkxtr/laravel-qrcode/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/linkxtr/laravel-qrcode/actions?query=workflow%3Arun-tests+branch%3Amain)
+[![Compatibility Test](https://github.com/linkxtr/laravel-qrcode/actions/workflows/compatibility-test.yml/badge.svg)](https://github.com/linkxtr/laravel-qrcode/actions/workflows/compatibility-test.yml)
+[![Total Downloads](https://img.shields.io/packagist/dt/linkxtr/laravel-qrcode.svg?style=flat-square)](https://packagist.org/packages/linkxtr/laravel-qrcode)
+[![License](https://img.shields.io/packagist/l/linkxtr/laravel-qrcode?style=flat-square)](LICENSE.md)
 
 A clean, modern, and easy-to-use QR code generator for Laravel applications. This package provides a simple and intuitive API for generating QR codes in various formats with support for Laravel 10, 11, and 12, built on top of the reliable [Bacon/BaconQrCode](https://github.com/Bacon/BaconQrCode) library.
+
+## 🚀 Simple QrCode Compatibility
+
+This package is designed to be a drop-in replacement for `simplesoftwareio/simple-qrcode` with the following benefits:
+
+- ✅ **Fully compatible** with existing Simple QrCode method signatures
+- 🚀 **Faster performance** with modern PHP 8.2+ optimizations
+- 🛠 **Strict type safety** with PHP 8.2+ features
+- 📦 **Smaller footprint** with minimal dependencies
+
+### Migration Guide
+
+If you're migrating from `simplesoftwareio/simple-qrcode`, simply replace the namespace in your code:
+
+```diff
+- use SimpleSoftwareIO\QrCode\Facades\QrCode;
++ use Linkxtr\QrCode\Facades\QrCode;
+```
+
+All your existing QR code generation code should work without any changes. We maintain compatibility with all the commonly used methods from Simple QrCode.
 
 ## Features
 
@@ -18,6 +39,8 @@ A clean, modern, and easy-to-use QR code generator for Laravel applications. Thi
 - 🧪 **100% test coverage** with Pest PHP
 - 📦 **Laravel 10, 11 & 12** compatibility
 - 🔍 **IDE-friendly** with proper type hints
+- 🔄 **Simple QrCode compatible** - Drop-in replacement for `simplesoftwareio/simple-qrcode`
+- 🚀 **Continuous compatibility testing** to ensure ongoing compatibility with Simple QrCode
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ All your existing QR code generation code should work without any changes. We ma
 You can install the package via Composer. This will automatically install the required `bacon/bacon-qr-code` package:
 
 ```bash
-composer require Linkxtr/laravel-qrcode
+composer require linkxtr/laravel-qrcode
 ```
 
 ## Basic Usage

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/pest",
-        "test-coverage": "XDEBUG_MODE=coverage vendor/bin/pest --coverage",
+        "test": "vendor/bin/pest --exclude-group=compatibility",
+        "test-coverage": "XDEBUG_MODE=coverage vendor/bin/pest --exclude-group=compatibility --coverage",
         "lint": "vendor/bin/pint",
         "analyse": "vendor/bin/phpstan analyse",
         "post-autoload-dump": [

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,6 @@
             }
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^8.2",
         "ext-gd": "*",
-        "bacon/bacon-qr-code": "^3.0",
+        "bacon/bacon-qr-code": "^2.0",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,32 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b40d78e021b2a61e9e6e8ad34b720ea3",
+    "content-hash": "e3e3ef94dc2508e3a7cfe24c216aa670",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
-            "version": "v3.0.1",
+            "version": "2.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Bacon/BaconQrCode.git",
-                "reference": "f9cc1f52b5a463062251d666761178dbdb6b544f"
+                "reference": "8674e51bb65af933a5ffaf1c308a660387c35c22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/f9cc1f52b5a463062251d666761178dbdb6b544f",
-                "reference": "f9cc1f52b5a463062251d666761178dbdb6b544f",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/8674e51bb65af933a5ffaf1c308a660387c35c22",
+                "reference": "8674e51bb65af933a5ffaf1c308a660387c35c22",
                 "shasum": ""
             },
             "require": {
                 "dasprid/enum": "^1.0.3",
                 "ext-iconv": "*",
-                "php": "^8.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "phly/keep-a-changelog": "^2.12",
-                "phpunit/phpunit": "^10.5.11 || 11.0.4",
-                "spatie/phpunit-snapshot-assertions": "^5.1.5",
-                "squizlabs/php_codesniffer": "^3.9"
+                "phly/keep-a-changelog": "^2.1",
+                "phpunit/phpunit": "^7 | ^8 | ^9",
+                "spatie/phpunit-snapshot-assertions": "^4.2.9",
+                "squizlabs/php_codesniffer": "^3.4"
             },
             "suggest": {
                 "ext-imagick": "to generate QR code images"
@@ -56,9 +56,9 @@
             "homepage": "https://github.com/Bacon/BaconQrCode",
             "support": {
                 "issues": "https://github.com/Bacon/BaconQrCode/issues",
-                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.0.1"
+                "source": "https://github.com/Bacon/BaconQrCode/tree/2.0.8"
             },
-            "time": "2024-10-01T13:55:55+00:00"
+            "time": "2022-12-07T17:46:57+00:00"
         },
         {
             "name": "brick/math",
@@ -1159,16 +1159,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.32.0",
+            "version": "v12.32.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "c30b044aae29ad87419ebedf377338bf4668a4c9"
+                "reference": "77b2740391cd2a825ba59d6fada45e9b8b9bcc5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/c30b044aae29ad87419ebedf377338bf4668a4c9",
-                "reference": "c30b044aae29ad87419ebedf377338bf4668a4c9",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/77b2740391cd2a825ba59d6fada45e9b8b9bcc5a",
+                "reference": "77b2740391cd2a825ba59d6fada45e9b8b9bcc5a",
                 "shasum": ""
             },
             "require": {
@@ -1374,7 +1374,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-09-30T10:30:26+00:00"
+            "time": "2025-09-30T17:39:22+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -7104,16 +7104,16 @@
         },
         {
             "name": "orchestra/sidekick",
-            "version": "v1.2.14",
+            "version": "v1.2.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orchestral/sidekick.git",
-                "reference": "0f7d1d96d390e7bf9118f280dfae74b8b2fb0a00"
+                "reference": "371ce2882ee3f5bf826b36e75d461e51c9cd76c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orchestral/sidekick/zipball/0f7d1d96d390e7bf9118f280dfae74b8b2fb0a00",
-                "reference": "0f7d1d96d390e7bf9118f280dfae74b8b2fb0a00",
+                "url": "https://api.github.com/repos/orchestral/sidekick/zipball/371ce2882ee3f5bf826b36e75d461e51c9cd76c2",
+                "reference": "371ce2882ee3f5bf826b36e75d461e51c9cd76c2",
                 "shasum": ""
             },
             "require": {
@@ -7126,7 +7126,7 @@
                 "laravel/framework": "^10.48.29|^11.44.7|^12.1.1|^13.0",
                 "laravel/pint": "^1.4",
                 "mockery/mockery": "^1.5.1",
-                "orchestra/testbench-core": "^8.37.0|^9.14.0|^10.0|^11.0",
+                "orchestra/testbench-core": "^8.37.0|^9.14.0|^10.2.0|^11.0",
                 "phpstan/phpstan": "^2.1.14",
                 "phpunit/phpunit": "^10.0|^11.0|^12.0",
                 "symfony/process": "^6.0|^7.0"
@@ -7155,9 +7155,9 @@
             "description": "Packages Toolkit Utilities and Helpers for Laravel",
             "support": {
                 "issues": "https://github.com/orchestral/sidekick/issues",
-                "source": "https://github.com/orchestral/sidekick/tree/v1.2.14"
+                "source": "https://github.com/orchestral/sidekick/tree/v1.2.17"
             },
-            "time": "2025-08-06T23:54:27+00:00"
+            "time": "2025-10-02T11:02:26+00:00"
         },
         {
             "name": "orchestra/testbench",
@@ -9913,7 +9913,7 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -65,7 +65,7 @@ class QrCode
      * SHIFT-JIS, WINDOWS-1250, WINDOWS-1251, WINDOWS-1252, WINDOWS-1256,
      * UTF-16BE, UTF-8, ASCII, GBK, EUC-KR.
      */
-    protected string $encoding = Encoder::DEFAULT_BYTE_MODE_ENCODING;
+    protected string $encoding = Encoder::DEFAULT_BYTE_MODE_ECODING;
 
     /**
      * The style of the blocks within the QrCode.

--- a/src/QrCode.php
+++ b/src/QrCode.php
@@ -41,7 +41,7 @@ class QrCode
     /**
      * The size of the QR code in pixels.
      */
-    protected int $size = 200;
+    protected int $size = 100;
 
     /**
      * The margin around the QR code.

--- a/tests/Compatibility/Datasets.php
+++ b/tests/Compatibility/Datasets.php
@@ -1,0 +1,21 @@
+<?php
+
+dataset('supported_methods', [
+    'Size' => ['size', 250],
+    'Color' => ['color', [0, 0, 0]],
+    'Background' => ['backgroundColor', [255, 255, 255]],
+    'Margin' => ['margin', 1],
+    'Encoding' => ['encoding', 'UTF-8'],
+    'Style' => ['style', 'dot'],
+    'Eye style' => ['eye', 'square'],
+    'Format' => ['format', 'svg'],
+]);
+
+dataset('content', [
+    'Text' => 'Simple text',
+    'URL' => 'https://example.com',
+    'Numbers' => '1234567890',
+    'Special Characters' => 'Special chars: !@#$%^&*()',
+    'Multibyte' => 'Multibyte: ñáéíóú',
+    'JSON' => 'JSON: {"name":"test","value":123}',
+]);

--- a/tests/Compatibility/SimpleQrCodeTest.php
+++ b/tests/Compatibility/SimpleQrCodeTest.php
@@ -4,8 +4,8 @@ use Illuminate\Support\Arr;
 
 test('can generate QR code with same output as Simple QrCode', function () {
     // Test with simple text
-    $simpleQr = \SimpleSoftwareIO\QrCode\Facades\QrCode::format('svg')->size(200)->generate('test');
-    $linkxtrQr = \Linkxtr\QrCode\Facades\QrCode::format('svg')->size(200)->generate('test');
+    $simpleQr = (new \SimpleSoftwareIO\QrCode\Generator)->format('svg')->size(200)->generate('test')->toHtml();
+    $linkxtrQr = (new \Linkxtr\QrCode\QrCode)->format('svg')->size(200)->generate('test')->toHtml();
 
     // Basic checks
     expect($linkxtrQr)->toBeString()
@@ -15,8 +15,8 @@ test('can generate QR code with same output as Simple QrCode', function () {
     // Test with different sizes
     $sizes = [100, 200, 300];
     foreach ($sizes as $size) {
-        $simpleQr = \SimpleSoftwareIO\QrCode\Facades\QrCode::format('svg')->size($size)->generate('size-test');
-        $linkxtrQr = \Linkxtr\QrCode\Facades\QrCode::format('svg')->size($size)->generate('size-test');
+        $simpleQr = (new \SimpleSoftwareIO\QrCode\Generator)->format('svg')->size($size)->generate('size-test')->toHtml();
+        $linkxtrQr = (new \Linkxtr\QrCode\QrCode)->format('svg')->size($size)->generate('size-test')->toHtml();
 
         // Check if both generate similar size SVGs
         $simpleSize = strlen($simpleQr);
@@ -31,11 +31,11 @@ test('can generate QR code with same output as Simple QrCode', function () {
     // Test error correction levels
     $levels = ['L', 'M', 'Q', 'H'];
     foreach ($levels as $level) {
-        $simpleQr = \SimpleSoftwareIO\QrCode\Facades\QrCode::format('svg')->size(200)->errorCorrection($level)->generate('error-correction');
-        $linkxtrQr = \Linkxtr\QrCode\Facades\QrCode::format('svg')
+        $simpleQr = (new \SimpleSoftwareIO\QrCode\Generator)->format('svg')->size(200)->errorCorrection($level)->generate('error-correction')->toHtml();
+        $linkxtrQr = (new \Linkxtr\QrCode\QrCode)->format('svg')
             ->errorCorrection($level)
             ->size(200)
-            ->generate('error-correction');
+            ->generate('error-correction')->toHtml();
 
         // Both should generate valid QR codes
         expect($simpleQr)->toBeString()
@@ -57,7 +57,7 @@ test('supports same methods as Simple QrCode', function () {
     ];
 
     foreach ($methods as $method => $value) {
-        $qrCode = \Linkxtr\QrCode\Facades\QrCode::{$method}(...Arr::wrap($value));
+        $qrCode = (new \Linkxtr\QrCode\QrCode)->{$method}(...Arr::wrap($value));
         expect($qrCode)->toBeInstanceOf(\Linkxtr\QrCode\QrCode::class);
     }
 })->group('compatibility');

--- a/tests/Compatibility/SimpleQrCodeTest.php
+++ b/tests/Compatibility/SimpleQrCodeTest.php
@@ -1,63 +1,19 @@
 <?php
 
 use Illuminate\Support\Arr;
+use Linkxtr\QrCode\QrCode as LinkxtrQr;
+use SimpleSoftwareIO\QrCode\Generator as SimpleQr;
 
-test('can generate QR code with same output as Simple QrCode', function () {
-    // Test with simple text
-    $simpleQr = (new \SimpleSoftwareIO\QrCode\Generator)->format('svg')->size(200)->generate('test')->toHtml();
-    $linkxtrQr = (new \Linkxtr\QrCode\QrCode)->format('svg')->size(200)->generate('test')->toHtml();
+pest()->group('compatibility');
 
-    // Basic checks
-    expect($linkxtrQr)->toBeString()
-        ->and(strlen($linkxtrQr))->toBeGreaterThan(100) // Ensure we have SVG content
-        ->and(str_contains($linkxtrQr, '<svg'))->toBeTrue();
+test('can generate QR code with same output as Simple QrCode', function (string $content) {
+    $linkxtr = (new LinkxtrQr)->format('svg')->generate($content);
+    $simple = (new SimpleQr)->format('svg')->generate($content);
 
-    // Test with different sizes
-    $sizes = [100, 200, 300];
-    foreach ($sizes as $size) {
-        $simpleQr = (new \SimpleSoftwareIO\QrCode\Generator)->format('svg')->size($size)->generate('size-test')->toHtml();
-        $linkxtrQr = (new \Linkxtr\QrCode\QrCode)->format('svg')->size($size)->generate('size-test')->toHtml();
+    expect($linkxtr->toHtml())->toBe($simple->toHtml());
+})->with('content');
 
-        // Check if both generate similar size SVGs
-        $simpleSize = strlen($simpleQr);
-        $linkxtrSize = strlen($linkxtrQr);
-
-        // Allow 10% difference in size due to potential implementation differences
-        expect($simpleSize)->toBeGreaterThan(0);
-        $sizeDifference = abs($simpleSize - $linkxtrSize) / $simpleSize;
-        expect($sizeDifference)->toBeLessThan(0.1);
-    }
-
-    // Test error correction levels
-    $levels = ['L', 'M', 'Q', 'H'];
-    foreach ($levels as $level) {
-        $simpleQr = (new \SimpleSoftwareIO\QrCode\Generator)->format('svg')->size(200)->errorCorrection($level)->generate('error-correction')->toHtml();
-        $linkxtrQr = (new \Linkxtr\QrCode\QrCode)->format('svg')
-            ->errorCorrection($level)
-            ->size(200)
-            ->generate('error-correction')->toHtml();
-
-        // Both should generate valid QR codes
-        expect($simpleQr)->toBeString()
-            ->and($linkxtrQr)->toBeString();
-    }
-})->group('compatibility');
-
-test('supports same methods as Simple QrCode', function () {
-    // Test common methods
-    $methods = [
-        'size' => 250,
-        'color' => [0, 0, 0],
-        'backgroundColor' => [255, 255, 255, 0],
-        'margin' => 1,
-        'encoding' => 'UTF-8',
-        'style' => 'dot',
-        'eye' => 'square',
-        'format' => 'svg',
-    ];
-
-    foreach ($methods as $method => $value) {
-        $qrCode = (new \Linkxtr\QrCode\QrCode)->{$method}(...Arr::wrap($value));
-        expect($qrCode)->toBeInstanceOf(\Linkxtr\QrCode\QrCode::class);
-    }
-})->group('compatibility');
+test('supports same methods as Simple QrCode', function (string $method, mixed $param) {
+    $qrCode = (new LinkxtrQr)->{$method}(...Arr::wrap($param));
+    expect($qrCode)->toBeInstanceOf(LinkxtrQr::class);
+})->with('supported_methods');

--- a/tests/Compatibility/SimpleQrCodeTest.php
+++ b/tests/Compatibility/SimpleQrCodeTest.php
@@ -2,19 +2,18 @@
 
 test('can generate QR code with same output as Simple QrCode', function () {
     // Test with simple text
-    $simpleQr = QrCode::format('svg')->size(200)->generate('test');
+    $simpleQr = \SimpleSoftwareIO\QrCode\Facades\QrCode::format('svg')->size(200)->generate('test');
     $linkxtrQr = \Linkxtr\QrCode\Facades\QrCode::format('svg')->size(200)->generate('test');
     
     // Basic checks
     expect($linkxtrQr)->toBeString()
         ->and(strlen($linkxtrQr))->toBeGreaterThan(100) // Ensure we have SVG content
-        ->and(str_contains($linkxtrQr, '<svg'))->toBeTrue()
-        ->and(str_contains($linkxtrQr, 'test'))->toBeTrue();
+        ->and(str_contains($linkxtrQr, '<svg'))->toBeTrue();
 
     // Test with different sizes
     $sizes = [100, 200, 300];
     foreach ($sizes as $size) {
-        $simpleQr = QrCode::format('svg')->size($size)->generate('size-test');
+        $simpleQr = \SimpleSoftwareIO\QrCode\Facades\QrCode::format('svg')->size($size)->generate('size-test');
         $linkxtrQr = \Linkxtr\QrCode\Facades\QrCode::format('svg')->size($size)->generate('size-test');
         
         // Check if both generate similar size SVGs
@@ -22,6 +21,7 @@ test('can generate QR code with same output as Simple QrCode', function () {
         $linkxtrSize = strlen($linkxtrQr);
         
         // Allow 10% difference in size due to potential implementation differences
+        expect($simpleSize)->toBeGreaterThan(0);
         $sizeDifference = abs($simpleSize - $linkxtrSize) / $simpleSize;
         expect($sizeDifference)->toBeLessThan(0.1);
     }
@@ -29,7 +29,7 @@ test('can generate QR code with same output as Simple QrCode', function () {
     // Test error correction levels
     $levels = ['L', 'M', 'Q', 'H'];
     foreach ($levels as $level) {
-        $simpleQr = QrCode::format('svg')->size(200)->errorCorrection($level)->generate('error-correction');
+        $simpleQr = \SimpleSoftwareIO\QrCode\Facades\QrCode::format('svg')->size(200)->errorCorrection($level)->generate('error-correction');
         $linkxtrQr = \Linkxtr\QrCode\Facades\QrCode::format('svg')
             ->errorCorrection($level)
             ->size(200)

--- a/tests/Compatibility/SimpleQrCodeTest.php
+++ b/tests/Compatibility/SimpleQrCodeTest.php
@@ -4,16 +4,14 @@ use Illuminate\Support\Arr;
 use Linkxtr\QrCode\QrCode as LinkxtrQr;
 use SimpleSoftwareIO\QrCode\Generator as SimpleQr;
 
-pest()->group('compatibility');
-
 test('can generate QR code with same output as Simple QrCode', function (string $content) {
     $linkxtr = (new LinkxtrQr)->format('svg')->generate($content);
     $simple = (new SimpleQr)->format('svg')->generate($content);
 
     expect($linkxtr->toHtml())->toBe($simple->toHtml());
-})->with('content');
+})->with('content')->group('compatibility');
 
 test('supports same methods as Simple QrCode', function (string $method, mixed $param) {
     $qrCode = (new LinkxtrQr)->{$method}(...Arr::wrap($param));
     expect($qrCode)->toBeInstanceOf(LinkxtrQr::class);
-})->with('supported_methods');
+})->with('supported_methods')->group('compatibility');

--- a/tests/Compatibility/SimpleQrCodeTest.php
+++ b/tests/Compatibility/SimpleQrCodeTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use Illuminate\Support\Arr;
+
 test('can generate QR code with same output as Simple QrCode', function () {
     // Test with simple text
     $simpleQr = \SimpleSoftwareIO\QrCode\Facades\QrCode::format('svg')->size(200)->generate('test');
     $linkxtrQr = \Linkxtr\QrCode\Facades\QrCode::format('svg')->size(200)->generate('test');
-    
+
     // Basic checks
     expect($linkxtrQr)->toBeString()
         ->and(strlen($linkxtrQr))->toBeGreaterThan(100) // Ensure we have SVG content
@@ -15,11 +17,11 @@ test('can generate QR code with same output as Simple QrCode', function () {
     foreach ($sizes as $size) {
         $simpleQr = \SimpleSoftwareIO\QrCode\Facades\QrCode::format('svg')->size($size)->generate('size-test');
         $linkxtrQr = \Linkxtr\QrCode\Facades\QrCode::format('svg')->size($size)->generate('size-test');
-        
+
         // Check if both generate similar size SVGs
         $simpleSize = strlen($simpleQr);
         $linkxtrSize = strlen($linkxtrQr);
-        
+
         // Allow 10% difference in size due to potential implementation differences
         expect($simpleSize)->toBeGreaterThan(0);
         $sizeDifference = abs($simpleSize - $linkxtrSize) / $simpleSize;
@@ -34,12 +36,12 @@ test('can generate QR code with same output as Simple QrCode', function () {
             ->errorCorrection($level)
             ->size(200)
             ->generate('error-correction');
-        
+
         // Both should generate valid QR codes
         expect($simpleQr)->toBeString()
             ->and($linkxtrQr)->toBeString();
     }
-});
+})->group('compatibility');
 
 test('supports same methods as Simple QrCode', function () {
     // Test common methods
@@ -55,7 +57,7 @@ test('supports same methods as Simple QrCode', function () {
     ];
 
     foreach ($methods as $method => $value) {
-        $qrCode = \Linkxtr\QrCode\Facades\QrCode::{$method}(...array_wrap($value));
+        $qrCode = \Linkxtr\QrCode\Facades\QrCode::{$method}(...Arr::wrap($value));
         expect($qrCode)->toBeInstanceOf(\Linkxtr\QrCode\QrCode::class);
     }
-});
+})->group('compatibility');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Updated badges; added a "Simple QrCode Compatibility" section with migration guidance and adjusted installation instructions to use the lowercase package name.

* Tests
  * Added compatibility tests verifying output parity and method support with Simple QrCode (compatibility group); CI test command now runs via composer test.

* Chores
  * Added CI compatibility workflow for PHP 8.2–8.3 across Laravel matrix; raised Composer minimum stability to stable and constrained a QR dependency version.

* Bug Fixes
  * Adjusted default QR size and encoding defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->