### PR TITLE
Fix SVG/EPS generation without image extensions (#40)

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -474,6 +474,13 @@ final class Generator
 
     private function getRenderer(): RendererInterface
     {
+        if (in_array($this->format, [Format::SVG, Format::EPS], true)) {
+            return new ImageRenderer(
+                $this->getRendererStyle(),
+                $this->getFormatter()
+            );
+        }
+
         if (! extension_loaded('imagick') && ! extension_loaded('gd')) {
             throw new RuntimeException('The imagick or gd extension is required to generate QR codes.');
         }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -10,6 +10,7 @@ use BaconQrCode\Renderer\Eye\CompositeEye;
 use BaconQrCode\Renderer\Eye\PointyEye;
 use BaconQrCode\Renderer\Eye\SimpleCircleEye;
 use BaconQrCode\Renderer\Eye\SquareEye;
+use BaconQrCode\Renderer\ImageRenderer;
 use BaconQrCode\Renderer\Module\DotsModule;
 use BaconQrCode\Renderer\Module\RoundnessModule;
 use BaconQrCode\Renderer\Module\SquareModule;
@@ -301,6 +302,15 @@ test('get renderer return a renderer instance', function () {
     $qrCode = new Generator;
     expect(invade($qrCode)->getRendererStyle())->not->toBeNull()->toBeInstanceOf(RendererStyle::class);
 });
+
+test('svg and eps renderers do not require imagick or gd extensions', function (string $format) {
+    $GLOBALS['mockImagickLoaded'] = false;
+    $GLOBALS['mockGdLoaded'] = false;
+
+    $qrCode = (new Generator)->format($format);
+
+    expect(invade($qrCode)->getRenderer())->toBeInstanceOf(ImageRenderer::class);
+})->with(['svg', 'eps']);
 
 it('throws exception if data type is not supported', function () {
     (new Generator)->notReal('fooBar');


### PR DESCRIPTION
## Summary
- Bypass raster extension checks for SVG and EPS output formats
- Keep existing Imagick/GD checks for PNG/WebP raster generation
- Add regression coverage for vector renderers when both extensions are unavailable

## Issue
Fixes https://github.com/Linkxtr/laravel-qrcode/issues/40

## Tests
- `php -l src/Generator.php`
- `php -l tests/GeneratorTest.php`
- `./vendor/bin/pint --test src/Generator.php tests/GeneratorTest.php`
- `./vendor/bin/pest tests/GeneratorTest.php --no-coverage --filter="svg and eps renderers do not require imagick or gd extensions"`

## Notes
- Ran with PHP 8.5.4 because the current lock file pulls Symfony/Laravel packages requiring PHP >=8.4.
- Full `tests/GeneratorTest.php --no-coverage` is blocked in this environment by missing Imagick; existing PNG/WebP tests set the mock extension flag true but BaconQrCode still requires the actual Imagick class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SVG and EPS format rendering now operates independently of GD and Imagick extension requirements, significantly enhancing server compatibility across diverse environments and eliminating unnecessary extension dependencies.

* **Tests**
  * Added tests verifying proper renderer selection for SVG and EPS formats, ensuring critical functionality is properly maintained when GD and Imagick extensions are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Linkxtr/laravel-qrcode/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->