### PR TITLE
test: restore mocked extension globals

### DIFF
--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -304,12 +304,29 @@ test('get renderer return a renderer instance', function () {
 });
 
 test('svg and eps renderers do not require imagick or gd extensions', function (string $format) {
+    $previousImagickLoaded = $GLOBALS['mockImagickLoaded'] ?? null;
+    $previousGdLoaded = $GLOBALS['mockGdLoaded'] ?? null;
+
     $GLOBALS['mockImagickLoaded'] = false;
     $GLOBALS['mockGdLoaded'] = false;
 
-    $qrCode = (new Generator)->format($format);
+    try {
+        $qrCode = (new Generator)->format($format);
 
-    expect(invade($qrCode)->getRenderer())->toBeInstanceOf(ImageRenderer::class);
+        expect(invade($qrCode)->getRenderer())->toBeInstanceOf(ImageRenderer::class);
+    } finally {
+        if ($previousImagickLoaded === null) {
+            unset($GLOBALS['mockImagickLoaded']);
+        } else {
+            $GLOBALS['mockImagickLoaded'] = $previousImagickLoaded;
+        }
+
+        if ($previousGdLoaded === null) {
+            unset($GLOBALS['mockGdLoaded']);
+        } else {
+            $GLOBALS['mockGdLoaded'] = $previousGdLoaded;
+        }
+    }
 })->with(['svg', 'eps']);
 
 it('throws exception if data type is not supported', function () {


### PR DESCRIPTION
## Summary
- Follow-up to #41 / #40 after review feedback.
- Restores the mocked extension globals after the SVG/EPS regression test so test state cannot leak into later tests.

## Tests
- php -l tests/GeneratorTest.php
- ./vendor/bin/pint --test tests/GeneratorTest.php

## Notes
- Targeted Pest is currently blocked in this local environment because Composer dependencies require PHP >= 8.4 while the local CLI is PHP 8.3.30 (symfony/clock requires php >=8.4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation to prevent cross-test interference and ensure consistent test execution across multiple test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Linkxtr/laravel-qrcode/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->