### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, 3.x, 2.x, 1.x ]
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
Potential fix for [https://github.com/Linkxtr/laravel-qrcode/security/code-scanning/1](https://github.com/Linkxtr/laravel-qrcode/security/code-scanning/1)

Add an explicit top-level `permissions` block to `.github/workflows/tests.yml` so all jobs inherit minimum required token scope.

Best fix here (without changing functionality): add at workflow root, near `name`/`on`, the minimal permission required by `actions/checkout` and this CI flow:

- `permissions:`
  - `contents: read`

This is sufficient for the current steps (checkout, setup, cache, install, test/lint/analyse) and avoids granting unnecessary write scopes. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configuration for CI/CD workflows by restricting permissions to the minimum required level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->