### PR TITLE
ci: add Dependabot configuration and update GitHub Actions workflows with pinning and coverage reporting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           name: coverage-report-${{ matrix.php }}-${{ matrix.laravel }}
           path: build/logs/clover.xml
+          if-no-files-found: error
 
   lint:
     name: Lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,10 +43,12 @@ jobs:
             testbench: ^11.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, gd, imagick
@@ -61,7 +63,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock', '**/composer.json') }}
@@ -78,23 +80,44 @@ jobs:
           mkdir -p build/logs
           composer test:unit
 
+      - name: Upload coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        if: always()
+        with:
+          name: coverage-report-${{ matrix.php }}-${{ matrix.laravel }}
+          path: build/logs/clover.xml
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
         with:
           php-version: 8.4
           extensions: dom, curl, libxml, mbstring
           tools: composer:v2
 
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock', '**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
       - name: Install Dependencies
         run: |
-          composer install --prefer-dist --no-progress --no-suggest --no-interaction
+          composer install --prefer-dist --no-progress --no-interaction
 
       - name: Run Pint
         run: composer test:lint
@@ -104,18 +127,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
         with:
           php-version: 8.4
           extensions: dom, curl, libxml, mbstring
           tools: composer:v2
 
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock', '**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
       - name: Install Dependencies
         run: |
-          composer install --prefer-dist --no-progress --no-suggest --no-interaction
+          composer install --prefer-dist --no-progress --no-interaction
 
       - name: Run PHPStan
         run: composer test:types

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "test:lint": "pint --parallel --test",
     "test:types": "phpstan analyse --ansi",
     "test:type-coverage": "pest --type-coverage --compact --coverage --min=100",
-    "test:unit": "pest --parallel --colors=always --coverage --min=100",
+    "test:unit": "pest --parallel --colors=always --coverage --min=100 --coverage-clover build/logs/clover.xml",
     "test": [
       "@test:refactor",
       "@test:lint",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated weekly dependency updates for GitHub Actions with labels and commit-prefix for CI changes.
  * Pinned CI action versions and adjusted workflow settings to improve reliability (checkout behavior and install flags).

* **Tests**
  * CI now uploads test coverage output as an artifact and test command updated to generate Clover coverage output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->