### PR TITLE
feat: add cache support to configuration and move file writing logic to QrCodeResult

### DIFF
--- a/config/qrcode.php
+++ b/config/qrcode.php
@@ -106,4 +106,15 @@ return [
     |
     */
     'force_gd' => env('QR_CODE_FORCE_GD', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Configuration
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the cache configuration of the QR code.
+    |
+    */
+    'cache_enabled' => env('QRCODE_CACHE_ENABLED', false),
+    'cache_ttl' => env('QRCODE_CACHE_TTL', 1440),
 ];

--- a/config/qrcode.php
+++ b/config/qrcode.php
@@ -115,6 +115,6 @@ return [
     | This option controls the cache configuration of the QR code.
     |
     */
-    'cache_enabled' => env('QRCODE_CACHE_ENABLED', false),
-    'cache_ttl' => env('QRCODE_CACHE_TTL', 1440),
+    'cache_enabled' => env('QR_CODE_CACHE_ENABLED', false),
+    'cache_ttl' => env('QR_CODE_CACHE_TTL', 1440),
 ];

--- a/src/DTOs/Config.php
+++ b/src/DTOs/Config.php
@@ -6,6 +6,8 @@ namespace Linkxtr\QrCode\DTOs;
 
 use BaconQrCode\Renderer\RendererStyle\EyeFill;
 use BaconQrCode\Renderer\RendererStyle\Gradient;
+use DateInterval;
+use DateTimeInterface;
 use Illuminate\Support\Facades\File;
 use Linkxtr\QrCode\Contracts\ColorInterface;
 use Linkxtr\QrCode\Enums\ColorModel;
@@ -116,6 +118,16 @@ final class Config
     private float $imagePercentage = .2;
 
     /**
+     * Whether the cache is enabled.
+     */
+    private bool $cacheEnabled = false;
+
+    /**
+     * The cache time to live.
+     */
+    private DateTimeInterface|DateInterval|int|null $cacheTtl = null;
+
+    /**
      * @param  array<mixed>  $config
      */
     public static function fromArray(array $config): self
@@ -154,6 +166,14 @@ final class Config
 
         if (isset($config['background_color']) && (is_string($config['background_color']) || is_array($config['background_color']))) {
             $instance->backgroundColorValue = Rgb::parse($config['background_color']);
+        }
+
+        if (isset($config['cache_enabled']) && is_bool($config['cache_enabled'])) {
+            $instance->cacheEnabled = $config['cache_enabled'];
+        }
+
+        if (isset($config['cache_ttl']) && is_int($config['cache_ttl'])) {
+            $instance->cacheTtl = $config['cache_ttl'];
         }
 
         return $instance;
@@ -439,6 +459,27 @@ final class Config
     public function getImagePercentage(): float
     {
         return $this->imagePercentage;
+    }
+
+    public function setupCache(DateTimeInterface|DateInterval|int|null $ttl = null): void
+    {
+        $this->cacheEnabled = true;
+        $this->cacheTtl = $ttl;
+    }
+
+    public function disableCache(): void
+    {
+        $this->cacheEnabled = false;
+    }
+
+    public function getCacheTtl(): int|DateInterval|DateTimeInterface
+    {
+        return $this->cacheTtl ?? 1440;
+    }
+
+    public function shouldCache(): bool
+    {
+        return $this->cacheEnabled;
     }
 
     private function isPathInsideApplication(string $resolvedPath): bool

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Linkxtr\QrCode;
 
 use Carbon\Carbon;
+use DateInterval;
 use DateTimeInterface;
 use Illuminate\Support\Traits\Macroable;
 use Linkxtr\QrCode\DTOs\Config;
@@ -14,9 +15,8 @@ use Linkxtr\QrCode\Enums\EyeStyle;
 use Linkxtr\QrCode\Enums\Format;
 use Linkxtr\QrCode\Enums\GradientType;
 use Linkxtr\QrCode\Enums\Style;
-use Linkxtr\QrCode\Exceptions\CannotWriteFileException;
 use Linkxtr\QrCode\Exceptions\InvalidMacroReturnTypeException;
-use Linkxtr\QrCode\Renderers\BaconRenderer;
+use Linkxtr\QrCode\Support\CacheManager;
 use Linkxtr\QrCode\Support\DataTypeResolver;
 use Linkxtr\QrCode\Support\QrCodeResult;
 use Linkxtr\QrCode\ValueObjects\Colors\Rgb;
@@ -85,22 +85,10 @@ final class Generator
 
     public function generate(string $text, ?string $filename = null): QrCodeResult
     {
-        $baconRenderer = new BaconRenderer($this->config);
-
-        $qrCodeResult = $baconRenderer->render($text);
+        $qrCodeResult = CacheManager::handle($this->config, $text);
 
         if ($filename !== null) {
-            $directory = dirname($filename);
-
-            if (! is_dir($directory)) {
-                throw CannotWriteFileException::toPath($filename);
-            }
-
-            $bytesWritten = @file_put_contents($filename, $qrCodeResult);
-
-            if ($bytesWritten === false) {
-                throw CannotWriteFileException::toPath($filename);
-            }
+            $qrCodeResult->saveToFile($filename);
         }
 
         return $qrCodeResult;
@@ -280,6 +268,24 @@ final class Generator
         $instance = clone $this;
 
         $instance->config->setMargin($margin);
+
+        return $instance;
+    }
+
+    public function cache(DateTimeInterface|DateInterval|int|null $ttl = null): static
+    {
+        $instance = clone $this;
+
+        $instance->config->setupCache($ttl);
+
+        return $instance;
+    }
+
+    public function withoutCache(): static
+    {
+        $instance = clone $this;
+
+        $instance->config->disableCache();
 
         return $instance;
     }

--- a/src/Support/CacheManager.php
+++ b/src/Support/CacheManager.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linkxtr\QrCode\Support;
+
+use Illuminate\Support\Facades\Cache;
+use Linkxtr\QrCode\DTOs\Config;
+use Linkxtr\QrCode\Renderers\BaconRenderer;
+
+final readonly class CacheManager
+{
+    public function __construct(private Config $config, private string $payload) {}
+
+    public static function handle(Config $config, string $paylod): QrCodeResult
+    {
+        $cache = new self($config, $paylod);
+
+        return $cache->getResult();
+    }
+
+    private function getResult(): QrCodeResult
+    {
+        if (! $this->config->shouldCache()) {
+            return $this->generate();
+        }
+
+        /** @var string $cachedQrCode */
+        $cachedQrCode = Cache::remember($this->getKey(), $this->config->getCacheTtl(), fn (): string => $this->generate()->__toString());
+
+        return new QrCodeResult($cachedQrCode, $this->config->getFormat());
+    }
+
+    private function generate(): QrCodeResult
+    {
+        $baconRenderer = new BaconRenderer($this->config);
+
+        return $baconRenderer->render($this->payload);
+    }
+
+    private function getKey(): string
+    {
+        $serializedConfig = serialize($this->config);
+
+        return 'qrcode_'.md5($this->payload.$serializedConfig);
+    }
+}

--- a/src/Support/QrCodeResult.php
+++ b/src/Support/QrCodeResult.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Linkxtr\QrCode\Enums\Format;
+use Linkxtr\QrCode\Exceptions\CannotWriteFileException;
 use Stringable;
 
 final readonly class QrCodeResult implements Htmlable, Responsable, Stringable
@@ -61,5 +62,20 @@ final readonly class QrCodeResult implements Htmlable, Responsable, Stringable
             Format::EPS => 'application/postscript',
             default => 'image/'.$this->format->value,
         };
+    }
+
+    public function saveToFile(string $filename): void
+    {
+        $directory = dirname($filename);
+
+        if (! is_dir($directory)) {
+            throw CannotWriteFileException::toPath($filename);
+        }
+
+        $bytesWritten = @file_put_contents($filename, $this->content);
+
+        if ($bytesWritten === false) {
+            throw CannotWriteFileException::toPath($filename);
+        }
     }
 }

--- a/tests/Support/Overrides.php
+++ b/tests/Support/Overrides.php
@@ -43,7 +43,7 @@ namespace Linkxtr\QrCode\DTOs {
     }
 }
 
-namespace Linkxtr\QrCode {
+namespace Linkxtr\QrCode\Support {
     if (! isset($GLOBALS['mockFilePutContents'])) {
         $GLOBALS['mockFilePutContents'] = null;
     }

--- a/tests/Unit/DTOs/ConfigTest.php
+++ b/tests/Unit/DTOs/ConfigTest.php
@@ -45,7 +45,9 @@ test('it initializes with default values', function (): void {
         ->and($config->getBackgroundColorValue()->red)->toBe(255)
         ->and($config->getBackgroundColorValue()->green)->toBe(255)
         ->and($config->getBackgroundColorValue()->blue)->toBe(255)
-        ->and($config->getBackgroundColorValue()->alpha)->toBe(100);
+        ->and($config->getBackgroundColorValue()->alpha)->toBe(100)
+        ->and($config->shouldCache())->toBe(false)
+        ->and($config->getCacheTtl())->toBe(1440);
 });
 
 test('it seeds configuration from array payload', function (): void {
@@ -57,6 +59,8 @@ test('it seeds configuration from array payload', function (): void {
         'encoding' => 'iso-8859-1',
         'color' => '10, 20, 30, 40',
         'background_color' => '0, 255, 0',
+        'cache_enabled' => true,
+        'cache_ttl' => 1441,
     ]);
 
     expect($config->getSize())->toBe(1)
@@ -71,7 +75,9 @@ test('it seeds configuration from array payload', function (): void {
         ->and($config->getBackgroundColorValue()->red)->toBe(0)
         ->and($config->getBackgroundColorValue()->green)->toBe(255)
         ->and($config->getBackgroundColorValue()->blue)->toBe(0)
-        ->and($config->getBackgroundColorValue()->alpha)->toBe(100);
+        ->and($config->getBackgroundColorValue()->alpha)->toBe(100)
+        ->and($config->shouldCache())->toBe(true)
+        ->and($config->getCacheTtl())->toBe(1441);
 });
 
 test('it falls back to default size when provide invalid size and margin', function (): void {
@@ -619,4 +625,21 @@ it('strictly normalizes backslashes to forward slashes for both base and resolve
     $resolvedPath = 'C:\\Fake\\Base\\Path\\storage\\image.png';
 
     expect(invade($config)->isPathInsideApplication($resolvedPath))->toBeTrue();
+});
+
+it('enables cache & sets ttl correctly when setupCache is called', function (): void {
+    $config = new Config;
+
+    $config->setupCache(1450);
+
+    expect($config->getCacheTtl())->toBe(1450)
+        ->and($config->shouldCache())->toBe(true);
+});
+
+it('disable cache correctly when disableCache called', function (): void {
+    $config = new Config;
+
+    $config->disableCache();
+
+    expect($config->shouldCache())->toBe(false);
 });

--- a/tests/Unit/GeneratorTest.php
+++ b/tests/Unit/GeneratorTest.php
@@ -10,7 +10,6 @@ use Linkxtr\QrCode\Enums\EyeStyle;
 use Linkxtr\QrCode\Enums\Format;
 use Linkxtr\QrCode\Enums\GradientType;
 use Linkxtr\QrCode\Enums\Style;
-use Linkxtr\QrCode\Exceptions\CannotWriteFileException;
 use Linkxtr\QrCode\Generator;
 use Linkxtr\QrCode\Support\QrCodeResult;
 
@@ -189,17 +188,16 @@ test('fluent configuration methods return a cloned instance with updated config'
         ->and(invade($merged2)->config->getImageMerge())->toBe($expectedContent)
         ->and(invade($merged2)->config->getImagePercentage())->toBe(0.2);
 
+    $cached = $generator->cache(5000);
+    expect($cached)->toBeInstanceOf(Generator::class)->not->toBe($generator)
+        ->and(invade($cached)->config->getCacheTtl())->toBe(5000)
+        ->and(invade($cached)->config->shouldCache())->toBe(true);
+
+    $notCached = $cached->withoutCache();
+    expect($notCached)->toBeInstanceOf(Generator::class)->not->toBe($cached)
+        ->and(invade($notCached)->config->shouldCache())->toBe(false);
+
     expect(invade($generator)->config->getSize())->toBe(400);
-});
-
-test('generate throws exception if file_put_contents fails', function (): void {
-    $generator = new Generator;
-
-    global $mockFilePutContents;
-    $mockFilePutContents = true;
-
-    expect(fn (): QrCodeResult => $generator->generate('fail-test', 'fail-test.svg'))
-        ->toThrow(RuntimeException::class, 'Failed to write QR code to file: fail-test.svg');
 });
 
 test('it mathematically rejects arrays and objects inside color configurations', function (): void {
@@ -210,30 +208,4 @@ test('it mathematically rejects arrays and objects inside color configurations',
 
     expect(fn (): Generator => $generator->gradient([255, 0, 0], [0, new stdClass, 0]))
         ->toThrow(InvalidArgumentException::class, 'RGB array values must be numeric.');
-});
-
-it('throws an exception when attempting to save to a non-existent directory', function (): void {
-    $generator = new Generator;
-
-    $invalidPath = __DIR__.'/this_directory_does_not_exist/qrcode.png';
-
-    expect(fn (): QrCodeResult => $generator->generate('Hello World', $invalidPath))
-        ->toThrow(CannotWriteFileException::class);
-});
-
-it('can successfully generate and save a qr code to a file', function (): void {
-    $generator = new Generator;
-
-    $tempFile = sys_get_temp_dir().'/test_qrcode_'.uniqid().'.svg';
-
-    if (file_exists($tempFile)) {
-        unlink($tempFile);
-    }
-
-    $generator->format('svg')->generate('Hello World', $tempFile);
-
-    expect(file_exists($tempFile))->toBeTrue()
-        ->and(filesize($tempFile))->toBeGreaterThan(0);
-
-    unlink($tempFile);
 });

--- a/tests/Unit/Support/CacheManagerTest.php
+++ b/tests/Unit/Support/CacheManagerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Cache;
+use Linkxtr\QrCode\DTOs\Config;
+use Linkxtr\QrCode\Support\CacheManager;
+use Linkxtr\QrCode\Support\QrCodeResult;
+
+covers(CacheManager::class);
+
+test('it completely bypasses the cache when caching is disabled to kill logic mutants', function (): void {
+    Cache::shouldReceive('remember')->never();
+
+    $config = Config::fromArray(['cache_enabled' => false]);
+    $qrCodeResult = CacheManager::handle($config, 'my-payload');
+
+    expect($qrCodeResult)->toBeInstanceOf(QrCodeResult::class);
+});
+
+test('it hits the cache and returns a valid result when caching is enabled', function (): void {
+    $config = Config::fromArray(['cache_enabled' => true, 'cache_ttl' => 600]);
+
+    Cache::shouldReceive('remember')
+        ->once()
+        ->withArgs(fn (string $key, int $ttl, Closure $callback): bool => str_starts_with($key, 'qrcode_') && $ttl === 600)
+        ->andReturn('fake-cached-svg-string');
+
+    $qrCodeResult = CacheManager::handle($config, 'my-payload');
+
+    expect($qrCodeResult)->toBeInstanceOf(QrCodeResult::class);
+});
+
+test('it strictly executes the closure to generate the qrcode on a cache miss', function (): void {
+    $config = Config::fromArray(['cache_enabled' => true]);
+
+    Cache::shouldReceive('remember')
+        ->once()
+        ->andReturnUsing(function ($key, $ttl, $closure) {
+            $generatedContent = $closure();
+
+            expect($generatedContent)->toBeString()->not->toBeEmpty();
+
+            return $generatedContent;
+        });
+
+    CacheManager::handle($config, 'my-payload');
+});
+
+test('it strictly formats the exact cache key to kill concatenation and hashing mutants', function (): void {
+    $config = Config::fromArray(['cache_enabled' => true]);
+    $payload = 'super-secret-payload';
+
+    $manager = new CacheManager($config, $payload);
+
+    $key = invade($manager)->getKey();
+
+    $expectedKey = 'qrcode_'.md5($payload.serialize($config));
+
+    expect($key)->toBe($expectedKey);
+});

--- a/tests/Unit/Support/QrCodeResultTest.php
+++ b/tests/Unit/Support/QrCodeResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Http\Response;
 use Linkxtr\QrCode\Enums\Format;
+use Linkxtr\QrCode\Exceptions\CannotWriteFileException;
 use Linkxtr\QrCode\Support\QrCodeResult;
 
 it('can be cast to a string', function (): void {
@@ -70,4 +71,40 @@ it('sets the correct content type for svg responses', function (): void {
     $response = $result->toResponse(request());
 
     expect($response->headers->get('Content-Type'))->toBe('image/svg+xml');
+});
+
+test('generate throws exception if file_put_contents fails', function (): void {
+    $result = new QrCodeResult('<svg></svg>', Format::SVG);
+
+    global $mockFilePutContents;
+    $mockFilePutContents = true;
+
+    expect(fn () => $result->saveToFile('fail-test.svg'))
+        ->toThrow(CannotWriteFileException::class, 'Failed to write QR code to file: fail-test.svg');
+});
+
+it('throws an exception when attempting to save to a non-existent directory', function (): void {
+    $result = new QrCodeResult('<svg></svg>', Format::SVG);
+
+    $invalidPath = __DIR__.'/this_directory_does_not_exist/qrcode.png';
+
+    expect(fn () => $result->saveToFile($invalidPath))
+        ->toThrow(CannotWriteFileException::class);
+});
+
+it('can successfully generate and save a qr code to a file', function (): void {
+    $result = new QrCodeResult('<svg></svg>', Format::SVG);
+
+    $tempFile = sys_get_temp_dir().'/test_qrcode_'.uniqid().'.svg';
+
+    if (file_exists($tempFile)) {
+        unlink($tempFile);
+    }
+
+    $result->saveToFile($tempFile);
+
+    expect(file_exists($tempFile))->toBeTrue()
+        ->and(filesize($tempFile))->toBeGreaterThan(0);
+
+    unlink($tempFile);
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional QR-code caching with configurable enablement and expiration settings.
  * Added fluent controls to enable caching with a custom duration or disable it per generation.
  * QR-code results can now be saved directly to files.
* **Bug Fixes**
  * Improved handling and reporting of file-save failures and missing directories.
* **Configuration**
  * Added environment-variable support for cache settings, disabled by default with a 1,440-minute default duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->